### PR TITLE
🆔 Update release ID

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -34,7 +34,7 @@ jobs:
         uses: flameddd/screenshots-ci-action@master
         with:
           url: ${{ steps.waitFor200.outputs.url }}/picture/
-          releaseId: 132409907
+          releaseId: 243448603
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
closes: #767 

Since the previous release was spilling over after more than 1000 files - jobs were hitting the "file_count limited to 1000 assets per release" error (HTTP 422).

After creating a new release, the ID needs to be updated accordingly.